### PR TITLE
Changed EnsureCreated to Migrate , handling database updates as well …

### DIFF
--- a/EFCoreLiveMigration/NeuroSpeech.EFCoreLiveMigration/MigrationHelper.cs
+++ b/EFCoreLiveMigration/NeuroSpeech.EFCoreLiveMigration/MigrationHelper.cs
@@ -31,7 +31,7 @@ namespace NeuroSpeech.EFCoreLiveMigration
 
         public void Migrate() {
 
-            context.Database.EnsureCreated();
+            context.Database.Migrate();
 
             foreach (var entity in context.Model.GetEntityTypes())
             {


### PR DESCRIPTION
I changed the database method call from EnsureCreated() to Migrate(). your live migrations was not handling database updates since EnsureCreated() does not store EF core history in the SQL Server.

I have tested this change with the provided console app and did not run into any outstanding errors. You will be my new best friend if we can make this change possible! I hate dealing with overflowing migration snapshot files.